### PR TITLE
fix port

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthcheck
-              port: 80
+              port: 5000
             initialDelaySeconds: 10
             periodSeconds: 10
             # failure if CI is busy for > 120 seconds


### PR DESCRIPTION
health check has been destroying CI lately because the port on the health check was wrong