### PR TITLE
Fix JSON Parsing & Target SHA Refresh

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -204,8 +204,8 @@ def refresh_deploy_jobs(jobs):
 @app.route('/force_retest', methods=['POST'])
 def force_retest():
     d = request.json
-    source = FQRef.from_json(d['source'])
-    target = FQRef.from_json(d['target'])
+    source = FQRef.from_json(json.loads(d['source']))
+    target = FQRef.from_json(json.loads(d['target']))
     prs.build(source, target)
     return '', 200
 
@@ -213,7 +213,7 @@ def force_retest():
 @app.route('/force_redeploy', methods=['POST'])
 def force_redeploy():
     d = request.json
-    target = FQRef.from_json(d['target'])
+    target = FQRef.from_json(json.loads(d['target']))
     if target in prs.watched_target_refs():
         prs.deploy(target)
         return '', 200

--- a/ci/github.py
+++ b/ci/github.py
@@ -23,6 +23,14 @@ def open_pulls(target_repo):
     return get_repo(target_repo.qname, 'pulls?state=open', status_code=200)
 
 
+def latest_sha_for_ref(ref):
+    d = get_repo(ref.repo.qname, f'git/refs/heads/{ref.name}', status_code=200)
+    assert 'object' in d, d
+    assert 'sha' in d['object'], d
+    return d['object']['sha']
+
+
+
 def overall_review_state(reviews):
     latest_state_by_login = {}
     for review in reviews:

--- a/ci/pr.py
+++ b/ci/pr.py
@@ -7,6 +7,7 @@ from ci_logging import log
 from constants import CONTEXT, BUILD_JOB_TYPE, VERSION, GCS_BUCKET, SHA_LENGTH
 from environment import PR_BUILD_SCRIPT, SELF_HOSTNAME, batch_client
 from git_state import FQSHA, FQRef
+from github import latest_sha_for_ref
 from http_helper import get_repo, post_repo, BadStatus
 from sentinel import Sentinel
 from shell_helper import shell
@@ -196,14 +197,7 @@ class GitHubPR(object):
 
     def to_PR(self, start_build=False):
         if self.target_sha is None:
-            d = get_repo(
-                self.target_ref.repo.qname,
-                f'git/refs/heads/{self.target_ref.name}',
-                status_code=200
-            )
-            assert 'object' in d, d
-            assert 'sha' in d['object'], d
-            target_sha = d['object']['sha']
+            target_sha = latest_sha_for_ref(self.target_ref)
         else:
             target_sha = self.target_sha
         target = FQSHA(self.target_ref, target_sha)

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: hail-ci
-          image: gcr.io/broad-ctsa/hail-ci:3bd98b9312a894a4e679f02fa23bda9e0a920d63
+          image: gcr.io/broad-ctsa/hail-ci:518a2d8142267e751afe854dccb1bd410419d321
           env:
             - name: SELF_HOSTNAME
               value: http://hail-ci


### PR DESCRIPTION
Without the JSON parsing, I cannot force retest (and thus force update
target shas). Moreover, without target SHA refresh, we have to wait for
a push webhook to inform us that the target has moved. The CI is
currently in a state where it doesn't know about the newest 0.1 SHA.