### PR TITLE
fix artifacts location and merge syntax

### DIFF
--- a/pr-build-script
+++ b/pr-build-script
@@ -11,7 +11,7 @@ echo $(git rev-parse $SOURCE_BRANCH) && \
 [[ $( git rev-parse target/$TARGET_BRANCH ) == $TARGET_SHA ]] && \
 git config user.email hail-ci-pr-builder@hail.is && \
 git config user.name "Hail CI PR Builder" && \
-git merge target/$TARGET_BRANCH $SOURCE_BRANCH && \
+git checkout target/$TARGET_BRANCH && git merge $SOURCE_BRANCH && \
 chmod 755 ./hail-ci-build.sh && \
 ./hail-ci-build.sh ; \
 BUILD_EXIT=$? ; ( \
@@ -23,7 +23,7 @@ BUILD_EXIT=$? ; ( \
     -h "Cache-Control:private, max-age=0, no-transform" \
     cp -r \
     artifacts/ \
-    gs://hail-ci-0-1/$SOURCE_SHA/$TARGET_SHA/ && \
-  gsutil -m acl ch -r -u AllUsers:R gs://hail-ci-0-1/$SOURCE_SHA/$TARGET_SHA/artifacts/ \
+    gs://hail-ci-0-1/ci/$SOURCE_SHA/$TARGET_SHA/ && \
+  gsutil -m acl ch -r -u AllUsers:R gs://hail-ci-0-1/ci/$SOURCE_SHA/$TARGET_SHA/artifacts/ \
 ) ) && \
 exit $BUILD_EXIT


### PR DESCRIPTION
When I switched from rebase to merge I screwed up the syntax. This syntax tries to merge both the target branch and the source branch into the current branch. The current branch should be the source branch. I think the syntax below is more clear. We checkout the target branch and merge the changes into that. This always forces a merge commit (whereas, previously, if we were up-to-date with master there would be no new commit).

Also, the artifacts were going to the wrong directory. I updated `gs://hail-ci-0-1/` to have `deploy` and `ci` sub directories but forgot to update the build script.