### PR TITLE
clean up deletion logic

### DIFF
--- a/ci/ci.py
+++ b/ci/ci.py
@@ -167,8 +167,6 @@ def refresh_ci_build_jobs(jobs):
                 try_to_cancel_job(job)
     for ((source, target), job) in latest_jobs.items():
         prs.refresh_from_ci_job(source, target, job)
-        if job.cached_status()['state'] != 'Created':
-            job.delete()
 
 def refresh_deploy_jobs(jobs):
     jobs = [
@@ -201,8 +199,6 @@ def refresh_deploy_jobs(jobs):
                 try_to_cancel_job(job)
     for (target, job) in latest_jobs.items():
         prs.refresh_from_deploy_job(target, job)
-        if job.cached_status()['state'] != 'Created':
-            job.delete()
 
 @app.route('/force_retest', methods=['POST'])
 def force_retest():

--- a/ci/pr.py
+++ b/ci/pr.py
@@ -440,6 +440,7 @@ class PR(object):
         elif state == 'Cancelled':
             log.error(
                 f'a job for me was cancelled {short_str_build_job(job)} {self.short_str()}')
+            job.delete()
             return self._new_build(try_new_build(self.source, self.target))
         else:
             assert state == 'Created', f'{state} {job.id} {job.attributes} {self.short_str()}'
@@ -447,6 +448,7 @@ class PR(object):
             assert 'image' in job.attributes, job.attributes
             target = FQSHA.from_json(json.loads(job.attributes['target']))
             image = job.attributes['image']
+            job.delete()
             if target == self.target:
                 return self._new_build(Building(job, image, target.sha))
             else:
@@ -461,6 +463,7 @@ class PR(object):
         assert job_source.ref == self.source.ref
         assert job_target.ref == self.target.ref
 
+        job.delete()
         if job_target.sha != self.target.sha:
             log.info(
                 f'notified of job for old target {job.id}'


### PR DESCRIPTION
In particular:

1. We already have deletes inside all the deploy job paths, so don't
   delete in the endpoint method.

2. We previously did not delete jobs when we receive a `/ci_build_done`,
   this change ensures we delete a job as soon as we update state from
   it (whether from `/ci_build_done` or a state refresh)