### PR TITLE
added gcr-push secret for hail-is/batch

### DIFF
--- a/ci/prs.py
+++ b/ci/prs.py
@@ -161,7 +161,8 @@ class PRS(object):
     _deploy_secrets = {
         Repo('hail-is', 'hail'): f'ci-deploy-{VERSION}--hail-is-hail-service-account-key',
         Repo('hail-is', 'ci-test'): f'ci-deploy-{VERSION}--hail-is-ci-test-service-account-key',
-        Repo('Nealelab', 'cloudtools'): f'ci-deploy-{VERSION}--nealelab-cloudtools'
+        Repo('Nealelab', 'cloudtools'): f'ci-deploy-{VERSION}--nealelab-cloudtools',
+        Repo('hail-is', 'batch'): 'gcr-push-service-account-key'
     }
 
     def try_deploy(self, target_ref):

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -21,7 +21,7 @@ spec:
             - name: BATCH_SERVER_URL
               value: http://batch
             - name: WATCHED_TARGETS
-              value: '[["hail-is/hail:master", true], ["hail-is/hail:0.1", true], ["hail-is/hail:bgen-changes", false], ["hail-is/batch:master", false], ["Nealelab/cloudtools:master", true]]'
+              value: '[["hail-is/hail:master", true], ["hail-is/hail:0.1", true], ["hail-is/hail:bgen-changes", false], ["hail-is/batch:master", true], ["Nealelab/cloudtools:master", true]]'
           ports:
             - containerPort: 5000
           volumeMounts:


### PR DESCRIPTION
I created gcr-push-service-account-key which has role/storage.admin on the bucket `artifacts.broad-ctsa.appspot.com` where the gcr.io images are stored (need for docker push).
