### PR TITLE
added hail-is/hail secrets

### DIFF
--- a/ci/prs.py
+++ b/ci/prs.py
@@ -159,7 +159,7 @@ class PRS(object):
             self._set(pr.source.ref, pr.target.ref, pr.build_it())
 
     _deploy_secrets = {
-        Repo('hail-is', 'hail'): f'ci-deploy-{VERSION}--hail-is-hail-service-account-key',
+        Repo('hail-is', 'hail'): f'hail-ci-deploy-hail-is-hail',
         Repo('Nealelab', 'cloudtools'): f'ci-deploy-{VERSION}--nealelab-cloudtools',
         Repo('hail-is', 'batch'): 'gcr-push-service-account-key'
     }


### PR DESCRIPTION
I created a secret `hail-ci-deploy-hail-is-hail` for the hail repo deploy and added the previous deploy service account key along with the GCR push key to it.  This will work for now.  I will think about the options for more systematic secret organization going forward.